### PR TITLE
refactor: Remove download of shopware-cli

### DIFF
--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -37,17 +37,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
 
-            - name: Download shopware-cli
-              run: |
-                git config --global --add safe.directory $(pwd)
-                wget -q https://github.com/FriendsOfShopware/shopware-cli/releases/download/${SHOPWARE_CLI_VERSION}/shopware-cli_Linux_x86_64.tar.gz
-                tar -zxf shopware-cli_*.tar.gz shopware-cli
-                mv shopware-cli /usr/bin/shopware-cli
-                rm shopware-cli_*.tar.gz
-
             - name: Build & create zip
               run: |
-                  /usr/bin/shopware-cli extension zip . --disable-git
+                  shopware-cli extension zip . --disable-git
 
             - name: Upload Artefact
               uses: actions/upload-artifact@v3


### PR DESCRIPTION
as it is included in the Docker image already